### PR TITLE
form null check

### DIFF
--- a/Plugins/SendTimestamps/SendTimestamps.plugin.js
+++ b/Plugins/SendTimestamps/SendTimestamps.plugin.js
@@ -267,6 +267,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
                 form = document.querySelector("form"),
                 button = DOMTools.createElement(buttonHTML);
             
+            if (!form) return; 
             if (form.querySelector(".timestamp-button")) return;
 
             if (this.settings.onRight) {


### PR DESCRIPTION
Added a single line `if (!form) return;` to resolve a potential error as well as getting rid of the annoying console message.