### PR TITLE
Fix: ret.props.children

### DIFF
--- a/Plugins/SendTimestamps/SendTimestamps.plugin.js
+++ b/Plugins/SendTimestamps/SendTimestamps.plugin.js
@@ -802,7 +802,7 @@ input[type='date']::-webkit-calendar-picker-indicator {
 
                                   if (timestamps.length > 0)
                                       try {
-                                          ret.props.children.push(
+                                          ret.props.children.props.children.push(
                                               React.createElement(TimestampFomratsSelector, {
                                                   timestamps,
                                                   onChange: (opts) => {


### PR DESCRIPTION
`ret.props.children` -> `ret.props.children.props.children` fixes error / timestamp formats quick select